### PR TITLE
Supabaseから直接データを入力できるようにCourseモデルを編集

### DIFF
--- a/prisma/migrations/20250823134803_add_course_updatedat/migration.sql
+++ b/prisma/migrations/20250823134803_add_course_updatedat/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `updatedAt` to the `Course` table without a default value. This is not possible if the table is not empty.
+  - Made the column `department` on table `Course` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."Course" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL,
+ALTER COLUMN "id" SET DEFAULT gen_random_uuid(),
+ALTER COLUMN "department" SET NOT NULL;

--- a/prisma/migrations/20250823135331_fix_course_department_slug/migration.sql
+++ b/prisma/migrations/20250823135331_fix_course_department_slug/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."Course" ALTER COLUMN "departmentSlug" DROP DEFAULT;

--- a/prisma/migrations/20250823165151_add_default_to_updatedat/migration.sql
+++ b/prisma/migrations/20250823165151_add_default_to_updatedat/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."Course" ALTER COLUMN "updatedAt" SET DEFAULT CURRENT_TIMESTAMP;

--- a/prisma/migrations/20250823170848_add_course_slug_optional/migration.sql
+++ b/prisma/migrations/20250823170848_add_course_slug_optional/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."Course" ALTER COLUMN "courseSlug" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,16 +28,17 @@ model Profile {
 }
 
 model Course {
-  id             String    @id @default(uuid()) @db.Uuid
+  id             String   @id @db.Uuid @default(dbgenerated("gen_random_uuid()"))
   faculty        String // 学部名
-  department     String? // 学科or専攻名
+  department     String // 学科or専攻名
   courseName     String // 講義名
   facultySlug    String // 学部名のスラッグ
-  departmentSlug String    @default("general") // 学科or専攻名のスラッグ
-  courseSlug     String // 講義名のスラッグ
+  departmentSlug String // 学科or専攻名のスラッグ
+  courseSlug     String? // 講義名のスラッグ
   courseCode     String? // 講義コード
   instructor     String? // 教授名
   createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @default(now()) @updatedAt
   threads        Thread[]
   articles       Article[]
 


### PR DESCRIPTION
## やったこと
- Supabaseで直接データを入力してもuuidが生成されるように(dbgenerated("gen_random_uuid()"))を追加
- updatedAtのカラムを追加
- courseSlugのNULLを許可するよう変更
- departmentのNULLは許可しないように変更

## 変更理由
- 講義を選択した時のURLは講義名のスラッグではなく、講義のidを使うことにしたため、講義スラッグを任意に変更(NULLを許可)した
  - もし講義名が変わってもidが変わらないため再利用できる
  - 講義名を英語に翻訳して講義スラッグとしてデータを入れる手間を省くため(運用コスト削減)

## 試したこと
- Supabseから直接講義のデータを入力することができた
- 以下の必須項目5つを入力してデータが生成された

### データに必要なもの(必須)
- 学部名
- 学科名
- 講義名
- 学部のスラッグ
- 学科のスラッグ

### データに必要なもの(任意)
- 講義名スラッグ (講義のスラッグはidにするため、これは必須にしない)
- 講義コード
- 教授名

### 自動生成されるもの
- id(uuid)
- createdAt
- updatedAt