### PR TITLE
Gridを用いて3列に並び替えた

### DIFF
--- a/app/component/CourseCardList.tsx
+++ b/app/component/CourseCardList.tsx
@@ -1,4 +1,4 @@
-import { Typography } from "@mui/material";
+import { Typography, Grid } from "@mui/material";
 import CourseCard from "@/app/component/CourseCard";
 
 type Course = { id: string; courseName: string; courseSlug: string | null };
@@ -29,17 +29,23 @@ const CourseCardList = ({
           講義が見つかりませんでした。
         </Typography>
       ) : (
-        <>
+        <Grid container spacing={4} mx={8}>
           {courses.map((course) => (
-            <CourseCard
+            <Grid
+              size={4}
               key={course.id}
-              courseName={course.courseName}
-              facultySlug={facultySlug}
-              departmentSlug={departmentSlug}
-              courseId={course.id}
-            />
+              display={"flex"}
+              justifyContent={"center"}
+            >
+              <CourseCard
+                courseName={course.courseName}
+                facultySlug={facultySlug}
+                departmentSlug={departmentSlug}
+                courseId={course.id}
+              />
+            </Grid>
           ))}
-        </>
+        </Grid>
       )}
     </>
   );


### PR DESCRIPTION
ぜんかいのArticleCardListをGridで並び替えたときと3列にした以外ほぼ同じ
<img width="1911" height="1063" alt="image" src="https://github.com/user-attachments/assets/f524dbd2-1b5e-470d-9b07-4e4d9397b51a" />
