### PR TITLE
ThreadMessageのコンポーネントの位置とフォントの修正

### DIFF
--- a/app/component/ThreadMessage.tsx
+++ b/app/component/ThreadMessage.tsx
@@ -14,7 +14,7 @@ const ThreadMessage: React.FC<ThreadMessageProps> = ({
   return (
     <Card
       sx={{
-        height: 100,
+        height: 110,
         width: "100%",
         flex: "0 0 auto", // Cardの大きさを可変的にしないために必須
         borderRadius: 0,


### PR DESCRIPTION
<img width="1919" height="1199" alt="スクリーンショット 2025-08-26 172753" src="https://github.com/user-attachments/assets/261dd6b5-3174-4640-9d17-d39e00a239af" />
