### PR TITLE
スレッドメッセージを作成・取得apiを作成・表示

### DIFF
--- a/app/api/threads/[threadId]/messages/route.ts
+++ b/app/api/threads/[threadId]/messages/route.ts
@@ -14,14 +14,14 @@ const Body = z.object({
 
 export async function POST(
   req: Request,
-  { params }: { params: { threadId: string } }
+  { params }: { params: Promise<{ threadId: string }> }
 ) {
   try {
     const { userId: clerkUserId } = await auth();
     if (!clerkUserId)
       return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
 
-    const { threadId } = params;
+    const { threadId } = await params;
     if (!threadId || !/^[0-9a-fA-F-]{36}$/.test(threadId)) {
       return NextResponse.json(
         { message: "threadId はUUID形式で指定してください。" },
@@ -101,10 +101,10 @@ export async function POST(
 
 export async function GET(
   req: Request,
-  { params }: { params: { threadId: string } }
+  { params }: { params: Promise<{ threadId: string }> }
 ) {
   try {
-    const { threadId } = params;
+    const { threadId } = await params;
     if (!threadId || !/^[0-9a-fA-F-]{36}$/.test(threadId)) {
       return NextResponse.json(
         { message: "threadId はUUID形式で指定してください。" },

--- a/app/api/threads/[threadId]/messages/route.ts
+++ b/app/api/threads/[threadId]/messages/route.ts
@@ -112,19 +112,9 @@ export async function GET(
       );
     }
 
-    const url = new URL(req.url);
-    const limit = Number(url.searchParams.get("limit") ?? 20);
-    const cursor = url.searchParams.get("cursor") ?? undefined;
-    const order =
-      (url.searchParams.get("order") ?? "asc").toLowerCase() === "desc"
-        ? "desc"
-        : "asc";
-
     const records = await prisma.threadMessage.findMany({
       where: { threadId },
-      orderBy: [{ createdAt: order }, { id: order }],
-      take: Math.min(Math.max(limit, 1), 100),
-      ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
       select: {
         id: true,
         body: true,
@@ -134,19 +124,14 @@ export async function GET(
       },
     });
 
-    const nextCursor =
-      records.length === limit ? records[records.length - 1].id : null;
-
     return NextResponse.json({
       messages: records.map((m) => ({
         id: m.id,
-        body: m.body,
+        content: m.body,
         createdAt: m.createdAt,
         editedAt: m.editedAt,
         author: m.author,
       })),
-      nextCursor,
-      hasMore: !!nextCursor,
     });
   } catch (e) {
     console.error(e);

--- a/app/api/threads/[threadId]/messages/route.ts
+++ b/app/api/threads/[threadId]/messages/route.ts
@@ -5,94 +5,37 @@ import { prisma } from "@/lib/prismaClient";
 
 export const runtime = "nodejs";
 
-const Body = z.object({
+const PathParams = z.object({
+  threadId: z.string().uuid("threadId はUUID形式で指定してください。"),
+});
+
+const PostBody = z.object({
   body: z
     .string()
     .min(1, "本文は必須です。")
     .max(2000, "本文は2000文字以内で入力してください。"),
 });
 
-export async function POST(
-  req: Request,
-  params: { params: Promise<{ threadId: string }> }
+export async function GET(
+  _req: Request,
+  //reqを使ってないことを_で明示している
+  { params }: { params: { threadId: string } }
 ) {
   try {
-    const { userId: clerkUserId } = await auth();
-    if (!clerkUserId) {
-      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
-    }
-
-    const { threadId } = await params.params;
-    if (!threadId || !/^[0-9a-fA-F-]{36}$/.test(threadId)) {
-      return NextResponse.json(
-        { message: "threadId はUUID形式で指定してください。" },
-        { status: 400 }
-      );
-    }
-
-    const json = await req.json();
-    const { body } = Body.parse(json);
-    const me = await prisma.profile.findUnique({
-      where: { clerkUserId },
-      select: { id: true },
-    });
-    if (!me) {
-      return NextResponse.json(
-        { message: "プロフィールが見つかりません。" },
-        { status: 404 }
-      );
-    }
-
-    const thread = await prisma.thread.findUnique({
-      where: { id: threadId },
-      select: { id: true },
-    });
-    if (!thread) {
-      return NextResponse.json(
-        { message: "スレッドが見つかりません。" },
-        { status: 404 }
-      );
-    }
-
-    const updated = await prisma.thread.update({
-      where: { id: threadId },
-      data: {
-        updatedAt: new Date(),
-        messages: { create: { authorId: me.id, body } },
-      },
+    const { threadId } = PathParams.parse(params);
+    const messages = await prisma.threadMessage.findMany({
+      where: { threadId },
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
       select: {
         id: true,
-        updatedAt: true,
-        messages: {
-          orderBy: [{ createdAt: "desc" }, { id: "desc" }],
-          take: 1,
-          select: {
-            id: true,
-            body: true,
-            createdAt: true,
-            editedAt: true,
-            author: { select: { handle: true, displayName: true } },
-          },
-        },
+        body: true,
+        createdAt: true,
+        editedAt: true,
+        author: { select: { handle: true, displayName: true } },
       },
     });
 
-    const created = updated.messages[0];
-
-    return NextResponse.json(
-      {
-        threadId: updated.id,
-        threadUpdatedAt: updated.updatedAt,
-        message: {
-          id: created.id,
-          content: created.body,
-          createdAt: created.createdAt,
-          editedAt: created.editedAt,
-          author: created.author,
-        },
-      },
-      { status: 201 }
-    );
+    return NextResponse.json({ messages });
   } catch (e) {
     if (e instanceof ZodError) {
       return NextResponse.json(
@@ -108,41 +51,83 @@ export async function POST(
   }
 }
 
-export async function GET(
+export async function POST(
   req: Request,
-  params: { params: Promise<{ threadId: string }> }
+  { params }: { params: { threadId: string } }
 ) {
   try {
-    const { threadId } = await params.params;
-    if (!threadId || !/^[0-9a-fA-F-]{36}$/.test(threadId)) {
+    const { userId: clerkUserId } = await auth();
+    if (!clerkUserId) {
+      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+    }
+
+    const { threadId } = PathParams.parse(params);
+    const { body } = PostBody.parse(await req.json());
+
+    const me = await prisma.profile.findUnique({
+      where: { clerkUserId },
+      select: { id: true },
+    });
+    if (!me) {
       return NextResponse.json(
-        { message: "threadId はUUID形式で指定してください。" },
-        { status: 400 }
+        { message: "プロフィールが見つかりません。" },
+        { status: 404 }
       );
     }
 
-    const records = await prisma.threadMessage.findMany({
-      where: { threadId },
-      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-      select: {
-        id: true,
-        body: true,
-        createdAt: true,
-        editedAt: true,
-        author: { select: { handle: true, displayName: true } },
-      },
-    });
+    try {
+      const updated = await prisma.thread.update({
+        where: { id: threadId },
+        data: {
+          messages: { create: { authorId: me.id, body } },
+        },
+        select: {
+          id: true,
+          updatedAt: true,
+          messages: {
+            orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+            take: 1,
+            select: {
+              id: true,
+              body: true,
+              createdAt: true,
+              editedAt: true,
+              author: { select: { handle: true, displayName: true } },
+            },
+          },
+        },
+      });
 
-    return NextResponse.json({
-      messages: records.map((m) => ({
-        id: m.id,
-        content: m.body,
-        createdAt: m.createdAt,
-        editedAt: m.editedAt,
-        author: m.author,
-      })),
-    });
+      const created = updated.messages[0];
+      return NextResponse.json(
+        {
+          threadId: updated.id,
+          threadUpdatedAt: updated.updatedAt,
+          message: created,
+        },
+        { status: 201 }
+      );
+    } catch (e: unknown) {
+      if (
+        typeof e === "object" &&
+        e !== null &&
+        "code" in e &&
+        (e as any).code === "P2025"
+      ) {
+        return NextResponse.json(
+          { message: "スレッドが見つかりません。" },
+          { status: 404 }
+        );
+      }
+      throw e;
+    }
   } catch (e) {
+    if (e instanceof ZodError) {
+      return NextResponse.json(
+        { message: "入力が不正です。", issues: e.issues },
+        { status: 400 }
+      );
+    }
     console.error(e);
     return NextResponse.json(
       { message: "Internal Server Error" },

--- a/app/api/threads/[threadId]/messages/route.ts
+++ b/app/api/threads/[threadId]/messages/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from "next/server";
+import { z, ZodError } from "zod";
+import { auth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/prismaClient";
+
+export const runtime = "nodejs";
+
+const Body = z.object({
+  body: z
+    .string()
+    .min(1, "本文は必須です。")
+    .max(2000, "本文は2000文字以内で入力してください。"),
+});
+
+export async function POST(
+  req: Request,
+  { params }: { params: { threadId: string } }
+) {
+  try {
+    const { userId: clerkUserId } = await auth();
+    if (!clerkUserId)
+      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+
+    const { threadId } = params;
+    if (!threadId || !/^[0-9a-fA-F-]{36}$/.test(threadId)) {
+      return NextResponse.json(
+        { message: "threadId はUUID形式で指定してください。" },
+        { status: 400 }
+      );
+    }
+
+    const json = await req.json();
+    const { body } = Body.parse(json);
+
+    const me = await prisma.profile.findUnique({
+      where: { clerkUserId },
+      select: { id: true },
+    });
+    if (!me)
+      return NextResponse.json(
+        { message: "プロフィールが見つかりません。" },
+        { status: 404 }
+      );
+
+    const thread = await prisma.thread.findUnique({
+      where: { id: threadId },
+      select: { id: true },
+    });
+    if (!thread)
+      return NextResponse.json(
+        { message: "スレッドが見つかりません。" },
+        { status: 404 }
+      );
+
+    const updated = await prisma.thread.update({
+      where: { id: threadId },
+      data: {
+        updatedAt: new Date(),
+        messages: { create: { authorId: me.id, body } },
+      },
+      select: {
+        id: true,
+        updatedAt: true,
+        messages: {
+          orderBy: { createdAt: "desc" },
+          take: 1,
+          select: {
+            id: true,
+            body: true,
+            createdAt: true,
+            editedAt: true,
+            author: { select: { handle: true, displayName: true } },
+          },
+        },
+      },
+    });
+
+    const created = updated.messages[0];
+    return NextResponse.json(
+      {
+        threadId: updated.id,
+        threadUpdatedAt: updated.updatedAt,
+        message: created,
+      },
+      { status: 201 }
+    );
+  } catch (e) {
+    if (e instanceof ZodError) {
+      return NextResponse.json(
+        { message: "入力が不正です。", issues: e.issues },
+        { status: 400 }
+      );
+    }
+    console.error(e);
+    return NextResponse.json(
+      { message: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/component/ThreadMessageList.tsx
+++ b/app/component/ThreadMessageList.tsx
@@ -1,6 +1,6 @@
 import ThreadMessage from "./ThreadMessage";
 
-type ThreadMessageItem = {
+export type ThreadMessageItem = {
   id: string;
   userName: string;
   threadMessage: string;
@@ -8,45 +8,14 @@ type ThreadMessageItem = {
 
 const ThreadMessageList = ({ items }: { items: ThreadMessageItem[] }) => {
   return (
-    // 以下のコメントアウトを外せばmapのコードができる。下手がきの<ThreadMessage />は全部消す
     <div>
-      {/* {items.map(({ id, userName, threadMessage }) => (
+      {items.map(({ id, userName, threadMessage }) => (
         <ThreadMessage
           key={id}
           userName={userName}
           threadMessage={threadMessage}
         />
-      ))} */}
-      <ThreadMessage
-        userName={"momo"}
-        threadMessage={
-          "スレッドのメッセージスレッドのメッセージスレッドのメッセージ"
-        }
-      />
-      <ThreadMessage
-        userName={"momo"}
-        threadMessage={
-          "スレッドのメッセージスレッドのメッセージスレッドのメッセージ"
-        }
-      />
-      <ThreadMessage
-        userName={"momo"}
-        threadMessage={
-          "スレッドのメッセージスレッドのメッセージスレッドのメッセージ"
-        }
-      />
-      <ThreadMessage
-        userName={"momo"}
-        threadMessage={
-          "スレッドのメッセージスレッドのメッセージスレッドのメッセージ"
-        }
-      />
-      <ThreadMessage
-        userName={"momo"}
-        threadMessage={
-          "スレッドのメッセージスレッドのメッセージスレッドのメッセージ"
-        }
-      />
+      ))}
     </div>
   );
 };

--- a/app/component/ThreadMessagePostField.tsx
+++ b/app/component/ThreadMessagePostField.tsx
@@ -1,34 +1,85 @@
-import { IconButton, InputAdornment, TextField } from "@mui/material";
+"use client";
+import { useState } from "react";
+import { Box, IconButton, TextField } from "@mui/material";
 import SendIcon from "@mui/icons-material/Send";
 
-const ThreadMessagePostField = () => {
+type ThreadMessageProps = {
+  threadId: string;
+  onPosted?: (item: {
+    id: string;
+    userName: string;
+    threadMessage: string;
+  }) => void;
+};
+
+export default function ThreadMessagePostField({
+  threadId,
+  onPosted,
+}: ThreadMessageProps) {
+  const [value, setValue] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit() {
+    if (!value.trim() || loading) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/threads/${threadId}/messages`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ body: value.trim() }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.message ?? "投稿に失敗しました。");
+
+      const m = data.message as {
+        id: string;
+        body: string;
+        author: { handle: string | null; displayName: string };
+      };
+
+      const newItem = {
+        id: m.id,
+        userName: m.author.handle ?? m.author.displayName,
+        threadMessage: m.body,
+      };
+
+      onPosted?.(newItem);
+      setValue("");
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    // Ctrl+Enter で送信（Macは metaKey）
+    if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+      e.preventDefault();
+      handleSubmit();
+    }
+  }
+
   return (
-    <div>
+    <Box display="flex" gap={1} alignItems="flex-end">
       <TextField
         variant="outlined"
         placeholder="スレッドで投稿する"
         multiline
-        sx={{
-          width: "100%",
-        }}
-        slotProps={{
-          input: {
-            endAdornment: (
-              <InputAdornment position="end">
-                <IconButton
-                  aria-label="送信"
-                  edge="end"
-                  sx={{ pr: 1, color: "#1E8093" }}
-                >
-                  <SendIcon />
-                </IconButton>
-              </InputAdornment>
-            ),
-          },
-        }}
+        minRows={2}
+        sx={{ width: "100%" }}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
       />
-    </div>
+      <IconButton
+        aria-label="送信"
+        onClick={handleSubmit}
+        disabled={loading || !value.trim()}
+        sx={{ color: "#1E8093" }}
+      >
+        <SendIcon />
+      </IconButton>
+    </Box>
   );
-};
-
-export default ThreadMessagePostField;
+}

--- a/app/component/ThreadMessageView.tsx
+++ b/app/component/ThreadMessageView.tsx
@@ -35,7 +35,7 @@ const ThreadMessageView: FC<ThreadMessageViewProps> = ({
     if (initialItems.length > 0) return;
     let aborted = false;
     (async () => {
-      const res = await fetch(`/api/threads/${threadId}/messages?limit=50`, {
+      const res = await fetch(`/api/threads/${threadId}/messages`, {
         cache: "no-store",
       });
       if (!res.ok) return;

--- a/app/component/ThreadMessageView.tsx
+++ b/app/component/ThreadMessageView.tsx
@@ -1,36 +1,47 @@
 "use client";
 import { Box, Typography } from "@mui/material";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import ThreadMessagePostField from "./ThreadMessagePostField";
 import ThreadMessageList from "./ThreadMessageList";
 
-export type ThreadMessageItem = {
+type ThreadMessageItem = {
   id: string;
   userName: string;
   threadMessage: string;
 };
 
-const ThreadMessageView = ({ items }: { items: ThreadMessageItem[] }) => {
+type Props = {
+  threadId: string;
+  title?: string;
+  initialItems?: ThreadMessageItem[];
+};
+
+const ThreadMessageView = ({
+  threadId,
+  title = "スレッドのタイトル！",
+  initialItems = [],
+}: Props) => {
+  const [items, setItems] = useState<ThreadMessageItem[]>(initialItems);
   const scrollerRef = useRef<HTMLDivElement | null>(null);
 
-  // 初回のマウント時に一番下へスクロール
+  // 初回 & items 変化時に最下部へ
   useEffect(() => {
     const el = scrollerRef.current;
     if (!el) return;
     requestAnimationFrame(() => {
       el.scrollTop = el.scrollHeight;
     });
-  }, []);
+  }, [items]);
 
   return (
     <Box
-      height={"80vh"}
-      width={"60vw"}
-      display={"flex"}
-      flexDirection={"column"}
+      height="80vh"
+      width="60vw"
+      display="flex"
+      flexDirection="column"
       border={1}
       borderRadius={1}
-      borderColor={"#CCCCCC"}
+      borderColor="#CCCCCC"
     >
       <Typography
         p={2}
@@ -38,21 +49,29 @@ const ThreadMessageView = ({ items }: { items: ThreadMessageItem[] }) => {
         fontWeight={600}
         color="#3C3C3C"
         borderBottom={1}
-        borderColor={"#CCCCCC"}
+        borderColor="#CCCCCC"
       >
-        スレッドのタイトル！
+        {title}
       </Typography>
+
       <Box
         ref={scrollerRef}
-        display={"flex"}
-        flexDirection={"column"}
+        flex={1}
+        display="flex"
+        flexDirection="column"
         gap={1}
+        px={2}
+        py={1}
         sx={{ overflowY: "auto", overflowX: "hidden" }}
       >
         <ThreadMessageList items={items} />
       </Box>
-      <Box p={2} borderTop={1} borderColor={"#CCCCCC"}>
-        <ThreadMessagePostField />
+
+      <Box p={2} borderTop={1} borderColor="#CCCCCC">
+        <ThreadMessagePostField
+          threadId={threadId}
+          onPosted={(newItem) => setItems((prev) => [...prev, newItem])}
+        />
       </Box>
     </Box>
   );

--- a/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
+++ b/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
@@ -28,7 +28,8 @@ async function getAllThreads(courseId: string): Promise<ThreadListItem[]> {
   return res.json();
 }
 
-export default async function CoursePage({ params }: { params: Params }) {
+export default async function CoursePage(props: { params: Params }) {
+  const { params } = await Promise.resolve(props);
   const { facultySlug, departmentSlug, courseId } = params;
   const cookieHeader = (await headers()).get("cookie") ?? "";
   const threads = await getAllThreads(courseId);

--- a/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
+++ b/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
@@ -18,8 +18,10 @@ type ThreadListItem = {
   author: { handle: string | null; displayName: string };
 };
 
-async function getAllThreads(courseId: string): Promise<ThreadListItem[]> {
-  const cookieHeader = (await headers()).get("cookie") ?? "";
+async function getAllThreads(
+  courseId: string,
+  cookieHeader: string
+): Promise<ThreadListItem[]> {
   const res = await fetch(
     `${process.env.APP_URL!}/api/threads?courseId=${courseId}`,
     { cache: "no-store", headers: { cookie: cookieHeader } }
@@ -31,9 +33,11 @@ async function getAllThreads(courseId: string): Promise<ThreadListItem[]> {
 export default async function CoursePage(props: { params: Params }) {
   const { params } = await Promise.resolve(props);
   const { facultySlug, departmentSlug, courseId } = params;
+
   const cookieHeader = (await headers()).get("cookie") ?? "";
-  const threads = await getAllThreads(courseId);
-  // スレッドメッセージを表示する対象スレッド
+  // ← cookie を渡して二重取得を回避
+  const threads = await getAllThreads(courseId, cookieHeader);
+  // スレッドメッセージを表示する対象スレッド（とりあえず先頭）
   const selected = threads[0] ?? null;
   let initialItems: { id: string; userName: string; threadMessage: string }[] =
     [];
@@ -48,7 +52,7 @@ export default async function CoursePage(props: { params: Params }) {
       initialItems = (data.messages ?? []).map((m: any) => ({
         id: m.id,
         userName: m.author?.handle ?? m.author?.displayName ?? "名無し",
-        threadMessage: m.content,
+        threadMessage: m.body,
       }));
     }
   }

--- a/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
+++ b/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
@@ -28,30 +28,26 @@ async function getAllThreads(courseId: string): Promise<ThreadListItem[]> {
   return res.json();
 }
 
-export default async function CoursePage({
-  params,
-}: {
-  params: Promise<Params>;
-}) {
-  const { facultySlug, departmentSlug, courseId } = await params;
+export default async function CoursePage({ params }: { params: Params }) {
+  const { facultySlug, departmentSlug, courseId } = params;
+  const cookieHeader = (await headers()).get("cookie") ?? "";
   const threads = await getAllThreads(courseId);
-  //selectedはスレッドメッセージを取得しているスレッド自体を指す
+  // スレッドメッセージを表示する対象スレッド
   const selected = threads[0] ?? null;
-
   let initialItems: { id: string; userName: string; threadMessage: string }[] =
     [];
+
   if (selected) {
-    const cookieHeader = (await headers()).get("cookie") ?? "";
     const res = await fetch(
-      `${process.env.APP_URL!}/api/threads/${selected.id}/messages?limit=50`,
+      `${process.env.APP_URL!}/api/threads/${selected.id}/messages`,
       { cache: "no-store", headers: { cookie: cookieHeader } }
     );
     if (res.ok) {
       const data = await res.json();
       initialItems = (data.messages ?? []).map((m: any) => ({
         id: m.id,
-        userName: m.author.handle ?? m.author.displayName,
-        threadMessage: m.body,
+        userName: m.author?.handle ?? m.author?.displayName ?? "名無し",
+        threadMessage: m.content,
       }));
     }
   }

--- a/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
+++ b/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
@@ -22,10 +22,7 @@ async function getAllThreads(courseId: string): Promise<ThreadListItem[]> {
   const cookieHeader = (await headers()).get("cookie") ?? "";
   const res = await fetch(
     `${process.env.APP_URL!}/api/threads?courseId=${courseId}`,
-    {
-      cache: "no-store",
-      headers: { cookie: cookieHeader },
-    }
+    { cache: "no-store", headers: { cookie: cookieHeader } }
   );
   if (!res.ok) return [];
   return res.json();
@@ -38,8 +35,29 @@ export default async function CoursePage({
 }) {
   const { facultySlug, departmentSlug, courseId } = await params;
   const threads = await getAllThreads(courseId);
+  //selectedはスレッドメッセージを取得しているスレッド自体を指す
+  const selected = threads[0] ?? null;
+
+  let initialItems: { id: string; userName: string; threadMessage: string }[] =
+    [];
+  if (selected) {
+    const cookieHeader = (await headers()).get("cookie") ?? "";
+    const res = await fetch(
+      `${process.env.APP_URL!}/api/threads/${selected.id}/messages?limit=50`,
+      { cache: "no-store", headers: { cookie: cookieHeader } }
+    );
+    if (res.ok) {
+      const data = await res.json();
+      initialItems = (data.messages ?? []).map((m: any) => ({
+        id: m.id,
+        userName: m.author.handle ?? m.author.displayName,
+        threadMessage: m.body,
+      }));
+    }
+  }
+
   return (
-    <Box display={"flex"} justifyContent={"space-between"}>
+    <Box display="flex" justifyContent="space-between">
       <Box>
         講義名講義名のスレッド
         <PostButton
@@ -54,13 +72,16 @@ export default async function CoursePage({
           <ThreadCardList items={threads} />
         )}
       </Box>
-      <Box my={2} mr={8}>
-        <ThreadMessageView
-          threadId={"008935e1-aeaf-4e5c-b706-5c47b5cd9448"}
-          title={"サンプルスレッドタイトル"}
-          initialItems={[]}
-        />
-      </Box>
+
+      {selected && (
+        <Box my={2} mr={8}>
+          <ThreadMessageView
+            threadId={selected.id}
+            title={selected.title}
+            initialItems={initialItems}
+          />
+        </Box>
+      )}
     </Box>
   );
 }

--- a/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
+++ b/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
@@ -55,7 +55,11 @@ export default async function CoursePage({
         )}
       </Box>
       <Box my={2} mr={8}>
-        <ThreadMessageView items={[]} />
+        <ThreadMessageView
+          threadId={"008935e1-aeaf-4e5c-b706-5c47b5cd9448"}
+          title={"サンプルスレッドタイトル"}
+          initialItems={[]}
+        />
       </Box>
     </Box>
   );


### PR DESCRIPTION
##  やったこと
- スレッドメッセージを作成・取得apiを作成・表示
- コンポーネントにtypescriptを当てて入れ物にして、ホームに設置
- ホームでfechし、selectedで指定しているselected(仮置きでthread[0]一番最初に投稿されたスレッド）のmessageを取得し・コンポーネントにitemとして渡している。
##  デモ動画
https://github.com/user-attachments/assets/4ff64d53-3fc8-495b-a126-8e347b59af0d
##  できてないこと
警告対応
awaitがうまく効かせることができなくて、警告が出ている。動作には今のところ影響が出ていないため、後で修正する形にして一旦PRを出させていただいた。
##  警告が出ている箇所のリストアップ
<img width="1170" height="625" alt="image" src="https://github.com/user-attachments/assets/c68e31f7-3c4f-4844-84af-5a18dad76db5" />
##  できてないことその2
selectedを動的に動かすことができてないため今はthread[0]しか取得できない。これも今後実装する必要がある
