### PR TITLE
スレッドメッセージの動的変更を実装

### DIFF
--- a/app/component/ThreadCard.module.css
+++ b/app/component/ThreadCard.module.css
@@ -1,0 +1,4 @@
+.active {
+  outline: 2px solid #1976d2;
+  background: rgba(25, 118, 210, 0.06);
+}

--- a/app/component/ThreadCard.tsx
+++ b/app/component/ThreadCard.tsx
@@ -5,6 +5,7 @@ type ThreadCardProps = {
   title: string;
   authorName: string;
   createdAt: string;
+  active?: boolean;
 };
 
 const ThreadCard: React.FC<ThreadCardProps> = ({

--- a/app/component/ThreadCard.tsx
+++ b/app/component/ThreadCard.tsx
@@ -1,5 +1,6 @@
 import { Card, Box, Typography, Avatar } from "@mui/material";
 import PersonIcon from "@mui/icons-material/Person";
+import styles from "./ThreadCard.module.css";
 
 type ThreadCardProps = {
   title: string;
@@ -12,11 +13,12 @@ const ThreadCard: React.FC<ThreadCardProps> = ({
   title,
   authorName,
   createdAt,
+  active = false,
 }) => {
   const dateLabel = new Date(createdAt).toLocaleDateString("ja-JP"); // YYYY/MM/DD
 
   return (
-    <Card sx={{ width: 300, borderRadius: 3, display: "flex" }}>
+    <Card aria-current={active ? "true" : undefined} className={active ? styles.active : undefined}  sx={{ width: 300, borderRadius: 3, display: "flex" }}>
       <Box width={8} bgcolor="#D9D9D9" borderRadius="8px 0 0 8px" />
       <Box width="100%" p={1}>
         <Typography fontSize={17} fontWeight="bold" color="#444444">

--- a/app/component/ThreadCardList.tsx
+++ b/app/component/ThreadCardList.tsx
@@ -1,24 +1,36 @@
 import { Stack } from "@mui/material";
 import ThreadCard from "./ThreadCard";
+import Link from "next/link";
 
-type ThreadListItem = {
-  id: string;
-  title: string;
-  createdAt: string;
-  author: { handle: string | null; displayName: string };
+type ThreadCardListProps = {
+  items: {
+    id: string;
+    title: string;
+    createdAt: string;
+    author: { handle: string | null; displayName: string };
+  }[];
+  selectedId: string | null;
+  basePath: string;
 };
 
-const ThreadCardList: React.FC<{ items: ThreadListItem[] }> = ({ items }) => (
-  <Stack direction="column" gap={2}>
-    {items.map(({ id, title, createdAt, author }) => (
-      <ThreadCard
-        key={id}
-        title={title}
-        createdAt={createdAt}
-        authorName={author.handle ?? author.displayName}
-      />
-    ))}
-  </Stack>
-);
-
+const ThreadCardList = ({ items, selectedId, basePath }: ThreadCardListProps) => {
+  return (
+           <Stack direction="column" spacing={2}>
+      {items.map((t) => {
+        const href = `${basePath}?t=${t.id}`;
+        const isActive = t.id === selectedId;
+        return (
+          <Link key={t.id} href={href} replace scroll={false} style={{ textDecoration: "none" }}>
+            <ThreadCard
+              title={t.title}
+              authorName={t.author.handle ?? t.author.displayName}
+              createdAt={t.createdAt}
+              active={isActive}
+            />
+          </Link>
+        );
+      })}
+    </Stack>
+  );
+};
 export default ThreadCardList;

--- a/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
+++ b/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
@@ -17,9 +17,6 @@ type ThreadListItem = {
   createdAt: string;
   author: { handle: string | null; displayName: string };
 };
-
-const BASE = process.env.APP_URL!.replace(/\/$/, "");
-
 async function getAllThreads(
   courseId: string,
   cookieHeader: string
@@ -62,6 +59,8 @@ export default async function CoursePage(props: {
       }));
     }
   }
+
+   const basePath = `/thread/${facultySlug}/${departmentSlug}/${courseId}`;
 
   return (
     <Box display="flex" justifyContent="space-between">

--- a/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
+++ b/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
@@ -30,12 +30,12 @@ async function getAllThreads(
 }
 
 export default async function CoursePage(props: {
-  params: Params;
+  params: Params | Promise<Params>;
   searchParams: { t?: string };
 }) {
-  const {  params, searchParams } = await Promise.resolve(props);
-  const { facultySlug, departmentSlug, courseId } = params;
-
+   const resolved = await Promise.resolve(props.params);
+const { facultySlug, departmentSlug, courseId } = resolved;
+const { searchParams } = props;
   const cookieHeader = (await headers()).get("cookie") ?? "";
   // ← cookie を渡して二重取得を回避
   const threads = await getAllThreads(courseId, cookieHeader);
@@ -75,7 +75,11 @@ export default async function CoursePage(props: {
             スレッドはまだありません
           </div>
         ) : (
-          <ThreadCardList items={threads} />
+         <ThreadCardList
+            items={threads}
+            selectedId={selected?.id ?? null}
+            basePath={basePath}
+          />
         )}
       </Box>
 

--- a/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
+++ b/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
@@ -86,6 +86,7 @@ const { searchParams } = props;
       {selected && (
         <Box my={2} mr={8}>
           <ThreadMessageView
+          key={selected.id}    
             threadId={selected.id}
             title={selected.title}
             initialItems={initialItems}

--- a/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
+++ b/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
@@ -43,8 +43,8 @@ export default async function CoursePage(props: {
   // ← cookie を渡して二重取得を回避
   const threads = await getAllThreads(courseId, cookieHeader);
   const fromUrl = searchParams?.t ?? null;
-  // スレッドメッセージを表示する対象スレッド（とりあえず先頭）
-  const selected = threads[0] ?? null;
+  // 選択スレッド表示
+  const selected = threads.find((t) => t.id === fromUrl) ?? threads[0] ?? null;
   let initialItems: { id: string; userName: string; threadMessage: string }[] =
     [];
 

--- a/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
+++ b/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
@@ -36,12 +36,13 @@ export default async function CoursePage(props: {
   params: Params;
   searchParams: { t?: string };
 }) {
-  const { params } = await Promise.resolve(props);
+  const {  params, searchParams } = await Promise.resolve(props);
   const { facultySlug, departmentSlug, courseId } = params;
 
   const cookieHeader = (await headers()).get("cookie") ?? "";
   // ← cookie を渡して二重取得を回避
   const threads = await getAllThreads(courseId, cookieHeader);
+  const fromUrl = searchParams?.t ?? null;
   // スレッドメッセージを表示する対象スレッド（とりあえず先頭）
   const selected = threads[0] ?? null;
   let initialItems: { id: string; userName: string; threadMessage: string }[] =

--- a/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
+++ b/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
@@ -18,6 +18,8 @@ type ThreadListItem = {
   author: { handle: string | null; displayName: string };
 };
 
+const BASE = process.env.APP_URL!.replace(/\/$/, "");
+
 async function getAllThreads(
   courseId: string,
   cookieHeader: string

--- a/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
+++ b/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
@@ -32,7 +32,10 @@ async function getAllThreads(
   return res.json();
 }
 
-export default async function CoursePage(props: { params: Params }) {
+export default async function CoursePage(props: {
+  params: Params;
+  searchParams: { t?: string };
+}) {
   const { params } = await Promise.resolve(props);
   const { facultySlug, departmentSlug, courseId } = params;
 

--- a/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
+++ b/app/thread/[facultySlug]/[departmentSlug]/[courseId]/page.tsx
@@ -68,7 +68,7 @@ export default async function CoursePage(props: {
         講義名講義名のスレッド
         <PostButton
           text="投稿する"
-          href={`/thread/${facultySlug}/${departmentSlug}/${courseId}/post`}
+          href={`${basePath}/post`}
         />
         {threads.length === 0 ? (
           <div style={{ padding: 8, color: "#666" }}>


### PR DESCRIPTION
##  やったこと
スレッドカードにリンクを持たせて、そのリンクから selected を動的に更新できるようにした
###  詳細
- URL クエリ導入：/thread/.../courseId?t=<threadId> を採用
- 選択ロジック（ハイブリッド）：searchParams.t と一致するスレッドがあればそれを選択、なければ先頭を選択
```const fromUrl = searchParams?.t ?? null;
const selected = threads.find(t => t.id === fromUrl) ?? threads[0] ?? null;
```
- ThreadCardList：各カードを <Link href={${basePath}?t=${t.id}} replace scroll={false}> でラップ
→ クリックで URL の ?t だけ差し替え、RSC 再実行で右ペイン更新
- ThreadCard：active?: boolean を追加（選択中スタイル用）
- className={active ? styles.active : undefined} を付与
- ThreadCard.module.css（または thread-card.module.css）に .active を追加（枠と淡い背景）
- ThreadMessageView：key={selected.id} を付け、スレッド切替時に再マウントして初期メッセージを確実に反映
#### 細かい整備：
- headers() の await を削除（同期 API）
- params を await Promise.resolve(...) で解決して courseId が undefined になる問題を解消
##  デモ動画
https://github.com/user-attachments/assets/3884916e-255d-4c94-9269-1903b539e081