### PR TITLE
検索ボックスのレスポンシブ対応

### DIFF
--- a/app/component/SearchBox.tsx
+++ b/app/component/SearchBox.tsx
@@ -5,7 +5,12 @@ const SearchBox = () => {
   return (
     <Box
       component="form"
-      sx={{ "& > :not(style)": { mt: 2, width: "50ch" } }}
+      sx={{
+        "& > :not(style)": {
+          mt: 2,
+          width: { xs: "40ch", md: "50ch" },
+        },
+      }}
       autoComplete="off"
       display={"flex"}
       justifyContent={"center"}


### PR DESCRIPTION
## やったこと
検索ボックスの幅をレスポンシブ対応しました
## スクリーンショット
<img width="1916" height="1136" alt="image" src="https://github.com/user-attachments/assets/dd5c00e6-6142-4e90-84ce-2eee9194d168" />
