### PR TITLE
『講義一覧』の文字の大きさと余白をレスポンシブ対応

### DIFF
--- a/app/component/CourseCardList.tsx
+++ b/app/component/CourseCardList.tsx
@@ -22,9 +22,9 @@ const CourseCardList = ({
     <>
       <Typography
         fontWeight={550}
-        fontSize={20}
+        fontSize={{ xs: 16, md: 20 }}
         color="#383838"
-        ml={3}
+        ml={{ xs: 1.5, md: 3 }}
         my={1}
         sx={{ mb: 2 }}
       >


### PR DESCRIPTION
## やったこと

『講義一覧』の文字の大きさと余白をレスポンシブ対応
## スクリーンショット
<img width="1919" height="1129" alt="image" src="https://github.com/user-attachments/assets/8f2e358e-520a-4428-b4b3-bbcee21cd6c1" />
