### PR TITLE
スレッドメッセージ選択機能の修正

### DIFF
--- a/app/component/ThreadCard.module.css
+++ b/app/component/ThreadCard.module.css
@@ -1,4 +1,0 @@
-.active {
-  outline: 2px solid #1976d2;
-  background: rgba(25, 118, 210, 0.06);
-}

--- a/app/component/ThreadCard.tsx
+++ b/app/component/ThreadCard.tsx
@@ -1,6 +1,6 @@
 import { Card, Box, Typography, Avatar, CardActionArea} from "@mui/material";
 import PersonIcon from "@mui/icons-material/Person";
-import NextLink from "next/link"; 
+import Link from "next/link"; 
 
 type ThreadCardProps = {
   threadId: string;
@@ -32,7 +32,7 @@ const href = `${basePath}?t=${threadId}`;
         outlineOffset: 0,
       }}>
       <CardActionArea
-        component={NextLink}     
+        component={Link}     
         href={href}
         replace                 
         scroll={false}          

--- a/app/component/ThreadCard.tsx
+++ b/app/component/ThreadCard.tsx
@@ -7,12 +7,14 @@ type ThreadCardProps = {
   authorName: string;
   createdAt: string;
   active?: boolean;
+  basePath: string;
 };
 
 const ThreadCard: React.FC<ThreadCardProps> = ({
   title,
   authorName,
   createdAt,
+  basePath,
   active = false,
 }) => {
   const dateLabel = new Date(createdAt).toLocaleDateString("ja-JP"); // YYYY/MM/DD

--- a/app/component/ThreadCard.tsx
+++ b/app/component/ThreadCard.tsx
@@ -1,8 +1,10 @@
-import { Card, Box, Typography, Avatar } from "@mui/material";
+import { Card, Box, Typography, Avatar, CardActionArea, Link } from "@mui/material";
 import PersonIcon from "@mui/icons-material/Person";
 import styles from "./ThreadCard.module.css";
+import NextLink from "next/link"; 
 
 type ThreadCardProps = {
+  threadId: string;
   title: string;
   authorName: string;
   createdAt: string;
@@ -11,16 +13,24 @@ type ThreadCardProps = {
 };
 
 const ThreadCard: React.FC<ThreadCardProps> = ({
+  threadId,
   title,
   authorName,
   createdAt,
   basePath,
   active = false,
 }) => {
-  const dateLabel = new Date(createdAt).toLocaleDateString("ja-JP"); // YYYY/MM/DD
-
+const dateLabel = new Date(createdAt).toLocaleDateString("ja-JP"); // YYYY/MM/DD
+const href = `${basePath}?t=${threadId}`;
   return (
     <Card aria-current={active ? "true" : undefined} className={active ? styles.active : undefined}  sx={{ width: 300, borderRadius: 3, display: "flex" }}>
+      <CardActionArea
+        component={NextLink}     
+        href={href}
+        replace                 
+        scroll={false}          
+        sx={{ height: "100%" }}
+      >
       <Box width={8} bgcolor="#D9D9D9" borderRadius="8px 0 0 8px" />
       <Box width="100%" p={1}>
         <Typography fontSize={17} fontWeight="bold" color="#444444">
@@ -40,6 +50,7 @@ const ThreadCard: React.FC<ThreadCardProps> = ({
           </Typography>
         </Box>
       </Box>
+      </CardActionArea>
     </Card>
   );
 };

--- a/app/component/ThreadCard.tsx
+++ b/app/component/ThreadCard.tsx
@@ -1,6 +1,5 @@
-import { Card, Box, Typography, Avatar, CardActionArea, Link } from "@mui/material";
+import { Card, Box, Typography, Avatar, CardActionArea} from "@mui/material";
 import PersonIcon from "@mui/icons-material/Person";
-import styles from "./ThreadCard.module.css";
 import NextLink from "next/link"; 
 
 type ThreadCardProps = {

--- a/app/component/ThreadCard.tsx
+++ b/app/component/ThreadCard.tsx
@@ -23,7 +23,15 @@ const ThreadCard: React.FC<ThreadCardProps> = ({
 const dateLabel = new Date(createdAt).toLocaleDateString("ja-JP"); // YYYY/MM/DD
 const href = `${basePath}?t=${threadId}`;
   return (
-    <Card aria-current={active ? "true" : undefined} className={active ? styles.active : undefined}  sx={{ width: 300, borderRadius: 3, display: "flex" }}>
+    <Card aria-current={active ? "true" : undefined}
+      sx={{
+        width: 300,
+        borderRadius: 3,
+        display: "flex",
+        outline: active ? "2px solid" : "0",
+        outlineColor: active ? "primary.main" : "transparent",
+        outlineOffset: 0,
+      }}>
       <CardActionArea
         component={NextLink}     
         href={href}

--- a/app/component/ThreadCardList.tsx
+++ b/app/component/ThreadCardList.tsx
@@ -1,6 +1,5 @@
 import { Stack } from "@mui/material";
 import ThreadCard from "./ThreadCard";
-import Link from "next/link";
 
 type ThreadCardListProps = {
   items: {
@@ -17,17 +16,16 @@ const ThreadCardList = ({ items, selectedId, basePath }: ThreadCardListProps) =>
   return (
            <Stack direction="column" spacing={2}>
       {items.map((t) => {
-        const href = `${basePath}?t=${t.id}`;
         const isActive = t.id === selectedId;
         return (
-          <Link key={t.id} href={href} replace scroll={false} style={{ textDecoration: "none" }}>
             <ThreadCard
+            key={t.id} 
+              threadId={t.id}  
               title={t.title}
               authorName={t.author.handle ?? t.author.displayName}
               createdAt={t.createdAt}
-              active={isActive}
-            />
-          </Link>
+              active={isActive} 
+              basePath={basePath}            />
         );
       })}
     </Stack>


### PR DESCRIPTION
##  やったこと
- 外部CSSを削除し、カード内でコードが完結するように
- リンクの直接ラップをカードアクションエリアに変更
## 詳細内容
### ThreadCard
- threadId prop を追加し、basePath と組み合わせて ${basePath}?t=${threadId} を生成。
- active の見た目を sx の outline 三項演算子で付与（外部 CSS なしで完結）。
### ThreadCardList
- 外側の <Link> ラップを 削除。
- ThreadCard に threadId / basePath / active を 直接渡すように変更。
## でも動画
https://github.com/user-attachments/assets/09d7794d-f7e2-4d8a-b2b5-b3d98e041ff5