### PR TITLE
記事リストのレスポンシブ対応

### DIFF
--- a/app/component/ArticleCardList.tsx
+++ b/app/component/ArticleCardList.tsx
@@ -14,9 +14,14 @@ const ArticleCardList = ({ items }: { items: ArticleItem[] }) => (
     <Box display={"flex"} justifyContent={"flex-end"} mr={5} my={3}>
       <PostButton text={"投稿する"} href={"/article/post"} />
     </Box>
-    <Grid container spacing={4} mx={8}>
+    <Grid container spacing={4} sx={{ mx: { xs: 2, sm: 8 } }}>
       {items.map(({ id, title, author }) => (
-        <Grid size={6} key={id} display={"flex"} justifyContent={"center"}>
+        <Grid
+          size={{ xs: 12, sm: 6 }}
+          key={id}
+          display={"flex"}
+          justifyContent={"center"}
+        >
           <ArticleCard
             authorName={author.handle ?? author.displayName}
             title={title}


### PR DESCRIPTION
スマホの時は一列になるようにした。また、スマホの時は、左右の余白が大きすぎたので小さくした。
<img width="1897" height="991" alt="image" src="https://github.com/user-attachments/assets/358e36d9-acf6-4392-9f2c-462836e618c5" />
<img width="1910" height="998" alt="image" src="https://github.com/user-attachments/assets/c8b6bcc1-59c6-4b95-95b5-9c9f5890a478" />
